### PR TITLE
fix: Remove depth constraint and add --all to fetch

### DIFF
--- a/internal/gitsync/gitsync.go
+++ b/internal/gitsync/gitsync.go
@@ -328,7 +328,6 @@ func cloneRepo(repo *config.RepositoryConfig) error {
 	if _, err := execCmd(
 		"git",
 		"clone",
-		"--depth", "1",
 		"--",
 		repo.URL,
 		path,
@@ -347,6 +346,7 @@ func updateTrackedRef(repo *config.RepositoryConfig) error {
 		"-C", path,
 		"fetch",
 		"--force",
+		"--all",
 	); err != nil {
 		return errors.Wrap(err, "failed to clone repository")
 	}


### PR DESCRIPTION
Currently it's impossible to define a different ref then the main branch of the repository.
With these changes it should be possible to define `ref` as `origin/branch-name`, pointing to arbitrary remote and local branches.