### PR TITLE
fix: Correct branch management

### DIFF
--- a/README.md
+++ b/README.md
@@ -140,7 +140,7 @@ The config file is a JSON file which describes the synchronization process.
       "name": "go-libyear",
       // Required. URL used to clone the repository.
       "url": "https://github.com/nieomylnieja/go-libyear.git",
-      // Optional. Default: "main".
+      // Optional. Default: "origin/main".
       "ref": "dev-branch",
       // Optional, merged with global 'ignore' section.
       // Follows the same format and rules but applies ONLY to the specified repository.

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -11,6 +11,8 @@ import (
 	"github.com/nieomylnieja/gitsync/internal/diff"
 )
 
+const defaultRef = "origin/main"
+
 type Config struct {
 	StorePath    string              `json:"storePath,omitempty"`
 	Root         *RepositoryConfig   `json:"root"`
@@ -117,7 +119,7 @@ func (c *Config) setDefaults() error {
 	for _, repo := range c.Repositories {
 		repo.path = filepath.Join(c.GetStorePath(), repo.Name)
 		if repo.Ref == "" {
-			repo.defaultRef = "main"
+			repo.defaultRef = defaultRef
 		}
 	}
 	c.Root.path = filepath.Join(c.GetStorePath(), c.Root.Name)
@@ -125,7 +127,7 @@ func (c *Config) setDefaults() error {
 		return errors.New("root repository cannot have ignore rules")
 	}
 	if c.Root.Ref == "" {
-		c.Root.defaultRef = "main"
+		c.Root.defaultRef = defaultRef
 	}
 	return nil
 }


### PR DESCRIPTION
Checking out latest tracked ref was not working correctly due to invalid `git` commands usage.