### PR TITLE
feat: Change hunks and regex into a list

### DIFF
--- a/README.md
+++ b/README.md
@@ -123,21 +123,26 @@ The config file is a JSON file which describes the synchronization process.
       "repositoryName": "go-libyear",
       // Optional. Name of the file to which the ignore rule applies.
       "fileName": "golangci linter config",
-      // Optional. Regular expression used to ignore matching hunks.
-      "regex": "^\\s*local-prefixes:"
+      // Optional. List of regular expressions used to ignore matching hunks.
+      // Note: This regular expression is passed to 'diff -I <regex>' and thus follows
+      // BRE (basic regular expression) rules, you may need to escape some characters, like '+'.
+      // Ref: https://www.gnu.org/software/grep/manual/html_node/Basic-vs-Extended.html.
+      "regex": ["^\\s\\+local-prefixes:"]
     },
     {
-      // Optional. Hunk to be ignored is represented with lines header and changes list.
+      // Optional. Hunks to be ignored are represented with lines header and changes list.
       // Either enter it manually or use the 'i' option in the sync command prompt.
       //
       // Ref: https://www.gnu.org/software/diffutils/manual/html_node/Detailed-Unified.html.
-      "hunk": {
+      "hunks": [{
+        // Optional. If lines are not provided the changes will be matched anywhere within the file.
         "lines": "@@ -3,0 +4,2 @@",
+        // Required.
         "changes": [
           "+  skip-dirs:",
           "+    - scripts"
         ]
-      }
+      }]
     }
   ],
   // Required. At least one repository must be provided.

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -58,10 +58,10 @@ type File struct {
 }
 
 type IgnoreRule struct {
-	RepositoryName *string    `json:"repositoryName,omitempty"`
-	FileName       *string    `json:"fileName,omitempty"`
-	Regex          *string    `json:"regex,omitempty"`
-	Hunk           *diff.Hunk `json:"hunk,omitempty"`
+	RepositoryName *string     `json:"repositoryName,omitempty"`
+	FileName       *string     `json:"fileName,omitempty"`
+	Regex          []string    `json:"regex,omitempty"`
+	Hunks          []diff.Hunk `json:"hunks,omitempty"`
 }
 
 func ReadConfig(configPath string) (*Config, error) {
@@ -94,6 +94,7 @@ func (c *Config) Save() error {
 	}
 	enc := json.NewEncoder(f)
 	enc.SetIndent("", "  ")
+	enc.SetEscapeHTML(false)
 	if err = enc.Encode(c); err != nil {
 		return fmt.Errorf("failed to save config: %w", err)
 	}
@@ -181,7 +182,7 @@ func (f *File) validate() error {
 }
 
 func (i *IgnoreRule) validate() error {
-	if i.Regex == nil && i.Hunk == nil {
+	if i.Regex == nil && i.Hunks == nil {
 		return errors.New("either 'regex' or 'hunk' needs to be defined")
 	}
 	return nil

--- a/internal/diff/diff.go
+++ b/internal/diff/diff.go
@@ -36,7 +36,7 @@ func (u UnifiedFormat) String(original bool) string {
 // Hunk represents a single diff hunk in of [UnifiedFormat].
 type Hunk struct {
 	// Lines is the '@@' header containing the line numbers.
-	Lines string `json:"lines"`
+	Lines string `json:"lines,omitempty"`
 	// Changes contains only the changed lines, without any context.
 	Changes []string `json:"changes"`
 	// Original is the original string representation of the hunk.
@@ -55,8 +55,10 @@ func (h Hunk) String() string {
 	return sb.String()
 }
 
+// Equal compares two [Hunk]s for equality.
+// It ignores color codes and will not compare [Hunk.Lines] if the receiver [Hunk] has no lines defined.
 func (h Hunk) Equal(other Hunk) bool {
-	if h.Lines != other.Lines || len(h.Changes) != len(other.Changes) {
+	if (h.Lines != "" && h.Lines != other.Lines) || len(h.Changes) != len(other.Changes) {
 		return false
 	}
 	for i := range h.Changes {


### PR DESCRIPTION
Both `hunk` and `regex` ignore rules are now a list, this helps limit the boilerplate of defining multiple exceptions for a single file.
Minor improvements and fixes to the docs and the program itself were also included.